### PR TITLE
REFACTOR: 게시글 조회 쿼리 회원과 페치 조인 후 조회

### DIFF
--- a/src/main/java/couch/camping/controller/post/dto/response/PostRetrieveResponseDto.java
+++ b/src/main/java/couch/camping/controller/post/dto/response/PostRetrieveResponseDto.java
@@ -27,17 +27,23 @@ public class PostRetrieveResponseDto {
     private List<String> imgUrlList = new ArrayList<>();
 
     private LocalDateTime createdDate;
+    
+    private String memberImgUrl;
 
-    public PostRetrieveResponseDto(Post findPost, int commentCnt, List<PostImage> postImageList) {
-        this.postId = findPost.getId();
-        this.memberId = findPost.getMember().getId();
-        this.content = findPost.getContent();
-        this.postType = findPost.getPostType();
-        this.likeCnt = findPost.getLikeCnt();
+    private String nickname;
+
+    public PostRetrieveResponseDto(Post post, int commentCnt, List<PostImage> postImageList) {
+        this.postId = post.getId();
+        this.memberId = post.getMember().getId();
+        this.content = post.getContent();
+        this.postType = post.getPostType();
+        this.likeCnt = post.getLikeCnt();
         this.commentCnt = commentCnt;
         for (PostImage postImage : postImageList) {
             imgUrlList.add(postImage.getImgUrl());
         }
-        this.createdDate = findPost.getCreatedDate();
+        this.createdDate = post.getCreatedDate();
+        this.memberImgUrl = post.getMember().getImgUrl();
+        this.nickname = post.getMember().getNickname();
     }
 }

--- a/src/main/java/couch/camping/domain/post/repository/PostCustomRepository.java
+++ b/src/main/java/couch/camping/domain/post/repository/PostCustomRepository.java
@@ -4,8 +4,10 @@ import couch.camping.domain.post.entity.Post;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
-public interface PostCustomRepository {
+import java.util.Optional;
 
-    Page<Post> findAllByIdWithPaging(String postType, Pageable pageable);
+public interface PostCustomRepository {
+    Optional<Post> findByIdWithFetchJoinMember(Long postId);
+    Page<Post> findAllByIdWithFetchJoinMemberPaging(String postType, Pageable pageable);
     Page<Post> findAllBestPost(Pageable pageable);
 }

--- a/src/main/java/couch/camping/domain/post/repository/PostCustomRepositoryImpl.java
+++ b/src/main/java/couch/camping/domain/post/repository/PostCustomRepositoryImpl.java
@@ -3,13 +3,16 @@ package couch.camping.domain.post.repository;
 import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import couch.camping.domain.post.entity.Post;
+import couch.camping.domain.post.entity.QPost;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.Pageable;
 
 import java.util.List;
+import java.util.Optional;
 
+import static couch.camping.domain.member.entity.QMember.member;
 import static couch.camping.domain.post.entity.QPost.post;
 
 @RequiredArgsConstructor
@@ -18,11 +21,12 @@ public class PostCustomRepositoryImpl implements PostCustomRepository{
     private final JPAQueryFactory queryFactory;
 
     @Override
-    public Page<Post> findAllByIdWithPaging(String postType, Pageable pageable) {
+    public Page<Post> findAllByIdWithFetchJoinMemberPaging(String postType, Pageable pageable) {
         List<Post> content = queryFactory
                 .select(post)
                 .from(post)
                 .where(getEq(postType))
+                .join(post.member, member).fetchJoin()
                 .offset(pageable.getOffset())
                 .limit(pageable.getPageSize())
                 .orderBy(post.createdDate.desc())
@@ -61,5 +65,17 @@ public class PostCustomRepositoryImpl implements PostCustomRepository{
                 .fetchOne();
 
         return new PageImpl<>(content, pageable, total);
+    }
+
+    @Override
+    public Optional<Post> findByIdWithFetchJoinMember(Long postId) {
+        Post post = queryFactory
+                .select(QPost.post)
+                .from(QPost.post)
+                .join(QPost.post.member, member).fetchJoin()
+                .where(QPost.post.id.eq(postId))
+                .fetchOne();
+
+        return Optional.ofNullable(post);
     }
 }

--- a/src/main/java/couch/camping/domain/post/service/PostService.java
+++ b/src/main/java/couch/camping/domain/post/service/PostService.java
@@ -117,11 +117,8 @@ public class PostService {
         }
     }
 
-    /**
-     * comment 필요
-     */
     public PostRetrieveResponseDto retrievePost(Long postId, String header) {
-        Post findPost = postRepository.findById(postId)
+        Post findPost = postRepository.findByIdWithFetchJoinMember(postId)
                 .orElseThrow(() -> {
                     throw new CustomException(ErrorCode.NOT_FOUND_POST, "게시글 ID 에 맞는 게시글이 없습니다.");
                 });
@@ -147,7 +144,7 @@ public class PostService {
             throw new CustomException(ErrorCode.BAD_REQUEST_PARAM, "쿼리스트링 postType 의 값은 all, free, picture, question 만 가능합니다.");
         }
         if (header == null) {
-            return postRepository.findAllByIdWithPaging(postType, pageable)
+            return postRepository.findAllByIdWithFetchJoinMemberPaging(postType, pageable)
                     .map(post -> new PostRetrieveResponseDto(post, post.getCommentList().size(), post.getPostImageList()));
         } else {
             Member member;
@@ -157,7 +154,7 @@ public class PostService {
                 throw new CustomException(ErrorCode.NOT_FOUND_MEMBER, "토큰에 해당하는 회원이 존재하지 않습니다.");
             }
 
-            return postRepository.findAllByIdWithPaging(postType, pageable)
+            return postRepository.findAllByIdWithFetchJoinMemberPaging(postType, pageable)
                     .map(post -> {
                         List<PostLike> postLikeList = post.getPostLikeList();
                         for (PostLike postLike : postLikeList) {


### PR DESCRIPTION
<br/>

## 해당 이슈 📎

- issue title #78 

  <br/>

## 변경 사항 🛠
- 게시글 조회 관련된 API 의 응답 값에 회원 닉네임, 이미지 url 의 필드 값을 추가했습니다.
- 추가된 필드에 따른 querydsl 쿼리에 페치 조인 추가

<br/>

## 리뷰어 참고 사항 🙋‍♀️
- 수정 사항은 응답 dto, querydsl 쿼리, 메서드 이름입니다.
<br/>
