### PR TITLE
REFACTOR: 게시글 도메인에 의존적인 댓글 컨틀롤러 분리 및 querydsl 빌드

### DIFF
--- a/build/generated/querydsl/couch/camping/domain/comment/entity/QComment.java
+++ b/build/generated/querydsl/couch/camping/domain/comment/entity/QComment.java
@@ -24,6 +24,8 @@ public class QComment extends EntityPathBase<Comment> {
 
     public final couch.camping.domain.base.QBaseEntity _super = new couch.camping.domain.base.QBaseEntity(this);
 
+    public final ListPath<couch.camping.domain.commentlike.entity.CommentLike, couch.camping.domain.commentlike.entity.QCommentLike> commentLikeList = this.<couch.camping.domain.commentlike.entity.CommentLike, couch.camping.domain.commentlike.entity.QCommentLike>createList("commentLikeList", couch.camping.domain.commentlike.entity.CommentLike.class, couch.camping.domain.commentlike.entity.QCommentLike.class, PathInits.DIRECT2);
+
     public final StringPath content = createString("content");
 
     //inherited

--- a/build/generated/querydsl/couch/camping/domain/post/entity/QPost.java
+++ b/build/generated/querydsl/couch/camping/domain/post/entity/QPost.java
@@ -26,6 +26,8 @@ public class QPost extends EntityPathBase<Post> {
 
     public final NumberPath<Integer> commentCnt = createNumber("commentCnt", Integer.class);
 
+    public final ListPath<couch.camping.domain.comment.entity.Comment, couch.camping.domain.comment.entity.QComment> commentList = this.<couch.camping.domain.comment.entity.Comment, couch.camping.domain.comment.entity.QComment>createList("commentList", couch.camping.domain.comment.entity.Comment.class, couch.camping.domain.comment.entity.QComment.class, PathInits.DIRECT2);
+
     public final StringPath content = createString("content");
 
     //inherited
@@ -47,6 +49,8 @@ public class QPost extends EntityPathBase<Post> {
     public final couch.camping.domain.member.entity.QMember member;
 
     public final ListPath<couch.camping.domain.postimage.entity.PostImage, couch.camping.domain.postimage.entity.QPostImage> postImageList = this.<couch.camping.domain.postimage.entity.PostImage, couch.camping.domain.postimage.entity.QPostImage>createList("postImageList", couch.camping.domain.postimage.entity.PostImage.class, couch.camping.domain.postimage.entity.QPostImage.class, PathInits.DIRECT2);
+
+    public final ListPath<couch.camping.domain.postlike.entity.PostLike, couch.camping.domain.postlike.entity.QPostLike> postLikeList = this.<couch.camping.domain.postlike.entity.PostLike, couch.camping.domain.postlike.entity.QPostLike>createList("postLikeList", couch.camping.domain.postlike.entity.PostLike.class, couch.camping.domain.postlike.entity.QPostLike.class, PathInits.DIRECT2);
 
     public final StringPath postType = createString("postType");
 

--- a/src/main/java/couch/camping/controller/comment/CommentController.java
+++ b/src/main/java/couch/camping/controller/comment/CommentController.java
@@ -1,25 +1,20 @@
 package couch.camping.controller.comment;
 
 import couch.camping.controller.comment.dto.request.CommentEditRequestDto;
-import couch.camping.controller.comment.dto.request.CommentWriteRequestDto;
 import couch.camping.controller.comment.dto.response.CommentEditResponseDto;
 import couch.camping.controller.comment.dto.response.CommentRetrieveResponseDto;
-import couch.camping.controller.comment.dto.response.CommentWriteResponseDto;
 import couch.camping.domain.comment.service.CommentService;
 import couch.camping.domain.member.entity.Member;
 import couch.camping.util.RequestUtil;
 import lombok.RequiredArgsConstructor;
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.Pageable;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.Authentication;
-import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.*;
 
 import javax.servlet.http.HttpServletRequest;
 
-@Controller
+@RestController
 @RequiredArgsConstructor
 public class CommentController {
 
@@ -31,24 +26,6 @@ public class CommentController {
                                                                       HttpServletRequest request){
         String header = RequestUtil.getAuthorizationToken(request);
         return ResponseEntity.ok(commentService.retrieveComment(commentId, header));
-    }
-
-    //게시글의 댓글 전체 조회
-    @GetMapping("posts/{postId}/comment")
-    public ResponseEntity<Page<CommentRetrieveResponseDto>> retrieveAllComment(@PathVariable Long postId,
-                                                                               HttpServletRequest request,
-                                                                               Pageable pageable){
-        String header = RequestUtil.getAuthorizationToken(request);
-        return ResponseEntity.ok(commentService.retrieveAllComment(postId, header, pageable));
-    }
-
-    //댓글 작성
-    @PostMapping("/posts/{postId}/comment") //이게 코멘트 컨트롤러에 있는 게 맞나?
-    public ResponseEntity<CommentWriteResponseDto> writeComment(@RequestBody CommentWriteRequestDto commentWriteRequestDto,
-                                                                @PathVariable Long postId,
-                                                                Authentication authentication){
-        Member member = (Member) authentication.getPrincipal();
-        return new ResponseEntity(commentService.writeComment(commentWriteRequestDto, member, postId), HttpStatus.CREATED);
     }
 
     //댓글 수정

--- a/src/main/java/couch/camping/controller/post/PostCommentController.java
+++ b/src/main/java/couch/camping/controller/post/PostCommentController.java
@@ -1,0 +1,43 @@
+package couch.camping.controller.post;
+
+import couch.camping.controller.comment.dto.request.CommentWriteRequestDto;
+import couch.camping.controller.comment.dto.response.CommentRetrieveResponseDto;
+import couch.camping.controller.comment.dto.response.CommentWriteResponseDto;
+import couch.camping.domain.comment.service.CommentService;
+import couch.camping.domain.member.entity.Member;
+import couch.camping.util.RequestUtil;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
+import org.springframework.web.bind.annotation.*;
+
+import javax.servlet.http.HttpServletRequest;
+
+@RestController
+@RequiredArgsConstructor
+public class PostCommentController {
+
+    private final CommentService commentService;
+
+    //게시글의 댓글 전체 조회
+    @GetMapping("/posts/{postId}/comment")
+    public ResponseEntity<Page<CommentRetrieveResponseDto>> retrieveAllComment(@PathVariable Long postId,
+                                                                               HttpServletRequest request,
+                                                                               Pageable pageable){
+        String header = RequestUtil.getAuthorizationToken(request);
+        return ResponseEntity.ok(commentService.retrieveAllComment(postId, header, pageable));
+    }
+
+    //댓글 작성
+    @PostMapping("/posts/{postId}/comment") //이게 코멘트 컨트롤러에 있는 게 맞나?
+    public ResponseEntity<CommentWriteResponseDto> writeComment(@RequestBody CommentWriteRequestDto commentWriteRequestDto,
+                                                                @PathVariable Long postId,
+                                                                Authentication authentication){
+        Member member = (Member) authentication.getPrincipal();
+        return new ResponseEntity(commentService.writeComment(commentWriteRequestDto, member, postId), HttpStatus.CREATED);
+    }
+
+}

--- a/src/main/java/couch/camping/controller/post/PostController.java
+++ b/src/main/java/couch/camping/controller/post/PostController.java
@@ -12,12 +12,11 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.Authentication;
-import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.*;
 
 import javax.servlet.http.HttpServletRequest;
 
-@Controller
+@RestController
 @RequiredArgsConstructor
 @RequestMapping("/posts")
 public class PostController {

--- a/src/main/java/couch/camping/domain/comment/service/CommentService.java
+++ b/src/main/java/couch/camping/domain/comment/service/CommentService.java
@@ -3,159 +3,24 @@ package couch.camping.domain.comment.service;
 import couch.camping.controller.comment.dto.request.CommentEditRequestDto;
 import couch.camping.controller.comment.dto.request.CommentWriteRequestDto;
 import couch.camping.controller.comment.dto.response.CommentEditResponseDto;
-import couch.camping.controller.comment.dto.response.CommentRetrieveLoginResponseDto;
 import couch.camping.controller.comment.dto.response.CommentRetrieveResponseDto;
 import couch.camping.controller.comment.dto.response.CommentWriteResponseDto;
-import couch.camping.domain.comment.entity.Comment;
-import couch.camping.domain.comment.repository.CommentRepository;
-import couch.camping.domain.commentlike.entity.CommentLike;
-import couch.camping.domain.commentlike.repository.CommentLikeRepository;
 import couch.camping.domain.member.entity.Member;
-import couch.camping.domain.post.entity.Post;
-import couch.camping.domain.post.repository.PostRepository;
-import couch.camping.exception.CustomException;
-import couch.camping.exception.ErrorCode;
-import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
-import org.springframework.security.core.userdetails.UserDetailsService;
-import org.springframework.security.core.userdetails.UsernameNotFoundException;
-import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
 
-import java.util.List;
-import java.util.Optional;
+public interface CommentService {
 
-@Service
-@RequiredArgsConstructor
-public class CommentService {
+    CommentWriteResponseDto writeComment(CommentWriteRequestDto commentWriteRequestDto, Member member, Long postId);
 
-    private final CommentRepository commentRepository;
-    private final CommentLikeRepository commentLikeRepository;
-    private final PostRepository postRepository;
-    private final UserDetailsService userDetailsService;
+    CommentEditResponseDto editComment(CommentEditRequestDto commentEditRequestDto, Member member, Long commentId);
 
-    @Transactional
-    public CommentWriteResponseDto writeComment(CommentWriteRequestDto commentWriteRequestDto, Member member, Long postId) {
+    void likeComment(Long commentId, Member member);
 
-        Post post = postRepository.findById(postId)
-                .orElseThrow(() -> {
-                    throw new CustomException(ErrorCode.NOT_FOUND_POST, "게시글 ID 에 맞는 게시글이 없습니다.");
-                });
+    CommentRetrieveResponseDto retrieveComment(Long commentId, String header);
 
-        Comment comment = Comment.builder()
-                .content(commentWriteRequestDto.getContent())
-                .member(member)
-                .post(post)
-                .build();
+    Page<CommentRetrieveResponseDto> retrieveAllComment(Long postId, String header, Pageable pageable);
 
-        Comment saveComment = commentRepository.save(comment);
+    void deleteComment(Long commentId, Member member);
 
-        return new CommentWriteResponseDto(saveComment);
-    }
-
-    @Transactional
-    public CommentEditResponseDto editComment(CommentEditRequestDto commentEditRequestDto, Member member, Long commentId) {
-
-        Comment findComment = commentRepository
-                .findById(commentId)
-                .orElseThrow(() -> {throw new CustomException(ErrorCode.NOT_FOUND_COMMENT, "댓글 ID에 맞는 댓글이 없습니다.");
-                });
-
-        if (findComment.getMember() != member){
-            throw new CustomException(ErrorCode.FORBIDDEN_MEMBER, "해당 회원의 댓글이 아닙니다.");
-        }
-
-        findComment.editComment(commentEditRequestDto.getContent());
-
-        return new CommentEditResponseDto(findComment);
-    }
-
-    @Transactional
-    public void likeComment(Long commentId, Member member) {
-        Comment findComment = commentRepository.findById(commentId)
-                .orElseThrow(() -> {
-                    throw new CustomException(ErrorCode.NOT_FOUND_COMMENT, "댓글 ID에 맞는 댓글이 없습니다.");
-                });
-
-        Optional<CommentLike> findCommentLike = commentLikeRepository.findByMemberIdAndCommentId(member.getId(), findComment.getId());
-
-        if (findCommentLike.isPresent()){
-            findComment.decreaseLikeCnt();
-            commentLikeRepository.deleteById(findCommentLike.get().getId());
-        } else {
-            findComment.increaseLikeCnt();
-            CommentLike commentLike = CommentLike.builder()
-                    .comment(findComment)
-                    .member(member)
-                    .build();
-            commentLikeRepository.save(commentLike);
-        }
-    }
-
-    public CommentRetrieveResponseDto retrieveComment(Long commentId, String header) {
-        Comment findComment = commentRepository.findIdWithFetchJoinMember(commentId)
-                .orElseThrow(() -> {
-                    throw new CustomException(ErrorCode.NOT_FOUND_COMMENT, "댓글 ID에 맞는 댓글이 없습니다.");
-                });
-
-        if (header == null) {
-            return new CommentRetrieveResponseDto(findComment);
-        } else {
-            Member member;
-            try {
-                member = (Member)userDetailsService.loadUserByUsername(header);
-            } catch (UsernameNotFoundException e) {
-                throw new CustomException(ErrorCode.NOT_FOUND_MEMBER, "토큰에 해당하는 회원이 존재하지 않습니다.");
-            }
-
-            List<CommentLike> commentLikeList = findComment.getCommentLikeList();
-            for (CommentLike commentLike : commentLikeList) {
-                if (commentLike.getMember() == member)
-                    return new CommentRetrieveLoginResponseDto(findComment, true);
-            }
-            return new CommentRetrieveLoginResponseDto(findComment, false);
-        }
-    }
-
-
-    public Page<CommentRetrieveResponseDto> retrieveAllComment(Long postId, String header, Pageable pageable) {
-
-        if (header == null) {
-            return commentRepository.findAllByIdWithFetchJoinMemberPaging(postId, pageable)
-                    .map(comment -> new CommentRetrieveResponseDto(comment));
-        } else {
-            Member member;
-            try {
-                member = (Member)userDetailsService.loadUserByUsername(header);
-            } catch (UsernameNotFoundException e) {
-                throw new CustomException(ErrorCode.NOT_FOUND_MEMBER, "토큰에 해당하는 회원이 존재하지 않습니다.");
-            }
-
-            return commentRepository.findAllByIdWithFetchJoinMemberPaging(postId, pageable)
-                    .map(comment -> {
-                        List<CommentLike> commentLikeList = comment.getCommentLikeList();
-                        for (CommentLike commentLike : commentLikeList) {
-                            if (commentLike.getMember() == member)
-                                return new CommentRetrieveLoginResponseDto(comment, true);
-                        }
-                        return new CommentRetrieveLoginResponseDto(comment, false);
-                    });
-        }
-    }
-
-    @Transactional
-    public void deleteComment(Long commentId, Member member) {
-
-        Comment findComment = commentRepository
-                .findById(commentId)
-                .orElseThrow(() -> {throw new CustomException(ErrorCode.NOT_FOUND_COMMENT, "댓글 ID에 맞는 댓글이 없습니다.");
-                });
-
-        if (findComment.getMember() != member){
-            throw new CustomException(ErrorCode.FORBIDDEN_MEMBER, "해당 회원의 댓글이 아닙니다.");
-        }
-
-        commentRepository.deleteById(commentId);
-    }
 }

--- a/src/main/java/couch/camping/domain/comment/service/CommentServiceImpl.java
+++ b/src/main/java/couch/camping/domain/comment/service/CommentServiceImpl.java
@@ -1,0 +1,174 @@
+package couch.camping.domain.comment.service;
+
+import com.google.firebase.auth.FirebaseAuth;
+import com.google.firebase.auth.FirebaseAuthException;
+import com.google.firebase.auth.FirebaseToken;
+import couch.camping.controller.comment.dto.request.CommentEditRequestDto;
+import couch.camping.controller.comment.dto.request.CommentWriteRequestDto;
+import couch.camping.controller.comment.dto.response.CommentEditResponseDto;
+import couch.camping.controller.comment.dto.response.CommentRetrieveLoginResponseDto;
+import couch.camping.controller.comment.dto.response.CommentRetrieveResponseDto;
+import couch.camping.controller.comment.dto.response.CommentWriteResponseDto;
+import couch.camping.domain.comment.entity.Comment;
+import couch.camping.domain.comment.repository.CommentRepository;
+import couch.camping.domain.commentlike.entity.CommentLike;
+import couch.camping.domain.commentlike.repository.CommentLikeRepository;
+import couch.camping.domain.member.entity.Member;
+import couch.camping.domain.post.entity.Post;
+import couch.camping.domain.post.repository.PostRepository;
+import couch.camping.exception.CustomException;
+import couch.camping.exception.ErrorCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Profile;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.Optional;
+
+@Profile("prod")
+@Service
+@RequiredArgsConstructor
+public class CommentServiceImpl implements CommentService {
+
+    private final CommentRepository commentRepository;
+    private final CommentLikeRepository commentLikeRepository;
+    private final PostRepository postRepository;
+    private final UserDetailsService userDetailsService;
+    private final FirebaseAuth firebaseAuth;
+
+    @Transactional
+    @Override
+    public CommentWriteResponseDto writeComment(CommentWriteRequestDto commentWriteRequestDto, Member member, Long postId) {
+
+        Post post = postRepository.findById(postId)
+                .orElseThrow(() -> {
+                    throw new CustomException(ErrorCode.NOT_FOUND_POST, "게시글 ID 에 맞는 게시글이 없습니다.");
+                });
+
+        Comment comment = Comment.builder()
+                .content(commentWriteRequestDto.getContent())
+                .member(member)
+                .post(post)
+                .build();
+
+        Comment saveComment = commentRepository.save(comment);
+
+        return new CommentWriteResponseDto(saveComment);
+    }
+
+    @Transactional
+    @Override
+    public CommentEditResponseDto editComment(CommentEditRequestDto commentEditRequestDto, Member member, Long commentId) {
+
+        Comment findComment = commentRepository
+                .findById(commentId)
+                .orElseThrow(() -> {throw new CustomException(ErrorCode.NOT_FOUND_COMMENT, "댓글 ID에 맞는 댓글이 없습니다.");
+                });
+
+        if (findComment.getMember() != member){
+            throw new CustomException(ErrorCode.FORBIDDEN_MEMBER, "해당 회원의 댓글이 아닙니다.");
+        }
+
+        findComment.editComment(commentEditRequestDto.getContent());
+
+        return new CommentEditResponseDto(findComment);
+    }
+
+    @Transactional
+    @Override
+    public void likeComment(Long commentId, Member member) {
+        Comment findComment = commentRepository.findById(commentId)
+                .orElseThrow(() -> {
+                    throw new CustomException(ErrorCode.NOT_FOUND_COMMENT, "댓글 ID에 맞는 댓글이 없습니다.");
+                });
+
+        Optional<CommentLike> findCommentLike = commentLikeRepository.findByMemberIdAndCommentId(member.getId(), findComment.getId());
+
+        if (findCommentLike.isPresent()){
+            findComment.decreaseLikeCnt();
+            commentLikeRepository.deleteById(findCommentLike.get().getId());
+        } else {
+            findComment.increaseLikeCnt();
+            CommentLike commentLike = CommentLike.builder()
+                    .comment(findComment)
+                    .member(member)
+                    .build();
+            commentLikeRepository.save(commentLike);
+        }
+    }
+
+    @Override
+    public CommentRetrieveResponseDto retrieveComment(Long commentId, String header) {
+        Comment findComment = commentRepository.findIdWithFetchJoinMember(commentId)
+                .orElseThrow(() -> {
+                    throw new CustomException(ErrorCode.NOT_FOUND_COMMENT, "댓글 ID에 맞는 댓글이 없습니다.");
+                });
+
+        if (header == null) {
+            return new CommentRetrieveResponseDto(findComment);
+        } else {
+            Member member;
+            try {
+                FirebaseToken decodedToken = firebaseAuth.verifyIdToken(header);
+                member = (Member)userDetailsService.loadUserByUsername(decodedToken.getUid());
+            } catch (UsernameNotFoundException | FirebaseAuthException | IllegalArgumentException e) {
+                throw new CustomException(ErrorCode.NOT_FOUND_MEMBER, "토큰에 해당하는 회원이 존재하지 않습니다.");
+            }
+
+            List<CommentLike> commentLikeList = findComment.getCommentLikeList();
+            for (CommentLike commentLike : commentLikeList) {
+                if (commentLike.getMember() == member)
+                    return new CommentRetrieveLoginResponseDto(findComment, true);
+            }
+            return new CommentRetrieveLoginResponseDto(findComment, false);
+        }
+    }
+
+
+    @Override
+    public Page<CommentRetrieveResponseDto> retrieveAllComment(Long postId, String header, Pageable pageable) {
+
+        if (header == null) {
+            return commentRepository.findAllByIdWithFetchJoinMemberPaging(postId, pageable)
+                    .map(comment -> new CommentRetrieveResponseDto(comment));
+        } else {
+            Member member;
+            try {
+                member = (Member)userDetailsService.loadUserByUsername(header);
+            } catch (UsernameNotFoundException e) {
+                throw new CustomException(ErrorCode.NOT_FOUND_MEMBER, "토큰에 해당하는 회원이 존재하지 않습니다.");
+            }
+
+            return commentRepository.findAllByIdWithFetchJoinMemberPaging(postId, pageable)
+                    .map(comment -> {
+                        List<CommentLike> commentLikeList = comment.getCommentLikeList();
+                        for (CommentLike commentLike : commentLikeList) {
+                            if (commentLike.getMember() == member)
+                                return new CommentRetrieveLoginResponseDto(comment, true);
+                        }
+                        return new CommentRetrieveLoginResponseDto(comment, false);
+                    });
+        }
+    }
+
+    @Transactional
+    @Override
+    public void deleteComment(Long commentId, Member member) {
+
+        Comment findComment = commentRepository
+                .findById(commentId)
+                .orElseThrow(() -> {throw new CustomException(ErrorCode.NOT_FOUND_COMMENT, "댓글 ID에 맞는 댓글이 없습니다.");
+                });
+
+        if (findComment.getMember() != member){
+            throw new CustomException(ErrorCode.FORBIDDEN_MEMBER, "해당 회원의 댓글이 아닙니다.");
+        }
+
+        commentRepository.deleteById(commentId);
+    }
+}

--- a/src/main/java/couch/camping/domain/comment/service/CommentServiceLocalImpl.java
+++ b/src/main/java/couch/camping/domain/comment/service/CommentServiceLocalImpl.java
@@ -1,0 +1,169 @@
+package couch.camping.domain.comment.service;
+
+import couch.camping.controller.comment.dto.request.CommentEditRequestDto;
+import couch.camping.controller.comment.dto.request.CommentWriteRequestDto;
+import couch.camping.controller.comment.dto.response.CommentEditResponseDto;
+import couch.camping.controller.comment.dto.response.CommentRetrieveLoginResponseDto;
+import couch.camping.controller.comment.dto.response.CommentRetrieveResponseDto;
+import couch.camping.controller.comment.dto.response.CommentWriteResponseDto;
+import couch.camping.domain.comment.entity.Comment;
+import couch.camping.domain.comment.repository.CommentRepository;
+import couch.camping.domain.commentlike.entity.CommentLike;
+import couch.camping.domain.commentlike.repository.CommentLikeRepository;
+import couch.camping.domain.member.entity.Member;
+import couch.camping.domain.post.entity.Post;
+import couch.camping.domain.post.repository.PostRepository;
+import couch.camping.exception.CustomException;
+import couch.camping.exception.ErrorCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Profile;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.Optional;
+
+@Profile("local")
+@Service
+@RequiredArgsConstructor
+public class CommentServiceLocalImpl implements CommentService {
+
+    private final CommentRepository commentRepository;
+    private final CommentLikeRepository commentLikeRepository;
+    private final PostRepository postRepository;
+    private final UserDetailsService userDetailsService;
+
+    @Transactional
+    @Override
+    public CommentWriteResponseDto writeComment(CommentWriteRequestDto commentWriteRequestDto, Member member, Long postId) {
+
+        Post post = postRepository.findById(postId)
+                .orElseThrow(() -> {
+                    throw new CustomException(ErrorCode.NOT_FOUND_POST, "게시글 ID 에 맞는 게시글이 없습니다.");
+                });
+
+        Comment comment = Comment.builder()
+                .content(commentWriteRequestDto.getContent())
+                .member(member)
+                .post(post)
+                .build();
+
+        Comment saveComment = commentRepository.save(comment);
+
+        return new CommentWriteResponseDto(saveComment);
+    }
+
+    @Transactional
+    @Override
+    public CommentEditResponseDto editComment(CommentEditRequestDto commentEditRequestDto, Member member, Long commentId) {
+
+        Comment findComment = commentRepository
+                .findById(commentId)
+                .orElseThrow(() -> {throw new CustomException(ErrorCode.NOT_FOUND_COMMENT, "댓글 ID에 맞는 댓글이 없습니다.");
+                });
+
+        if (findComment.getMember() != member){
+            throw new CustomException(ErrorCode.FORBIDDEN_MEMBER, "해당 회원의 댓글이 아닙니다.");
+        }
+
+        findComment.editComment(commentEditRequestDto.getContent());
+
+        return new CommentEditResponseDto(findComment);
+    }
+
+    @Transactional
+    @Override
+    public void likeComment(Long commentId, Member member) {
+        Comment findComment = commentRepository.findById(commentId)
+                .orElseThrow(() -> {
+                    throw new CustomException(ErrorCode.NOT_FOUND_COMMENT, "댓글 ID에 맞는 댓글이 없습니다.");
+                });
+
+        Optional<CommentLike> findCommentLike = commentLikeRepository.findByMemberIdAndCommentId(member.getId(), findComment.getId());
+
+        if (findCommentLike.isPresent()){
+            findComment.decreaseLikeCnt();
+            commentLikeRepository.deleteById(findCommentLike.get().getId());
+        } else {
+            findComment.increaseLikeCnt();
+            CommentLike commentLike = CommentLike.builder()
+                    .comment(findComment)
+                    .member(member)
+                    .build();
+            commentLikeRepository.save(commentLike);
+        }
+    }
+
+    @Override
+    public CommentRetrieveResponseDto retrieveComment(Long commentId, String header) {
+        Comment findComment = commentRepository.findIdWithFetchJoinMember(commentId)
+                .orElseThrow(() -> {
+                    throw new CustomException(ErrorCode.NOT_FOUND_COMMENT, "댓글 ID에 맞는 댓글이 없습니다.");
+                });
+
+        if (header == null) {
+            return new CommentRetrieveResponseDto(findComment);
+        } else {
+            Member member;
+            try {
+                member = (Member)userDetailsService.loadUserByUsername(header);
+            } catch (UsernameNotFoundException e) {
+                throw new CustomException(ErrorCode.NOT_FOUND_MEMBER, "토큰에 해당하는 회원이 존재하지 않습니다.");
+            }
+
+            List<CommentLike> commentLikeList = findComment.getCommentLikeList();
+            for (CommentLike commentLike : commentLikeList) {
+                if (commentLike.getMember() == member)
+                    return new CommentRetrieveLoginResponseDto(findComment, true);
+            }
+            return new CommentRetrieveLoginResponseDto(findComment, false);
+        }
+    }
+
+
+    @Override
+    public Page<CommentRetrieveResponseDto> retrieveAllComment(Long postId, String header, Pageable pageable) {
+
+        if (header == null) {
+            return commentRepository.findAllByIdWithFetchJoinMemberPaging(postId, pageable)
+                    .map(comment -> new CommentRetrieveResponseDto(comment));
+        } else {
+            Member member;
+            try {
+                member = (Member)userDetailsService.loadUserByUsername(header);
+            } catch (UsernameNotFoundException e) {
+                throw new CustomException(ErrorCode.NOT_FOUND_MEMBER, "토큰에 해당하는 회원이 존재하지 않습니다.");
+            }
+
+            return commentRepository.findAllByIdWithFetchJoinMemberPaging(postId, pageable)
+                    .map(comment -> {
+                        List<CommentLike> commentLikeList = comment.getCommentLikeList();
+                        for (CommentLike commentLike : commentLikeList) {
+                            if (commentLike.getMember() == member)
+                                return new CommentRetrieveLoginResponseDto(comment, true);
+                        }
+                        return new CommentRetrieveLoginResponseDto(comment, false);
+                    });
+        }
+    }
+
+    @Transactional
+    @Override
+    public void deleteComment(Long commentId, Member member) {
+
+        Comment findComment = commentRepository
+                .findById(commentId)
+                .orElseThrow(() -> {throw new CustomException(ErrorCode.NOT_FOUND_COMMENT, "댓글 ID에 맞는 댓글이 없습니다.");
+                });
+
+        if (findComment.getMember() != member){
+            throw new CustomException(ErrorCode.FORBIDDEN_MEMBER, "해당 회원의 댓글이 아닙니다.");
+        }
+
+        commentRepository.deleteById(commentId);
+    }
+}

--- a/src/main/java/couch/camping/domain/post/service/PostService.java
+++ b/src/main/java/couch/camping/domain/post/service/PostService.java
@@ -3,186 +3,26 @@ package couch.camping.domain.post.service;
 import couch.camping.controller.post.dto.request.PostEditRequestDto;
 import couch.camping.controller.post.dto.request.PostWriteRequestDto;
 import couch.camping.controller.post.dto.response.PostEditResponseDto;
-import couch.camping.controller.post.dto.response.PostRetrieveLoginResponseDto;
 import couch.camping.controller.post.dto.response.PostRetrieveResponseDto;
 import couch.camping.controller.post.dto.response.PostWriteResponseDto;
-import couch.camping.domain.comment.repository.CommentRepository;
 import couch.camping.domain.member.entity.Member;
-import couch.camping.domain.post.entity.Post;
-import couch.camping.domain.post.repository.PostRepository;
-import couch.camping.domain.postimage.entity.PostImage;
-import couch.camping.domain.postimage.repository.PostImageRepository;
-import couch.camping.domain.postlike.entity.PostLike;
-import couch.camping.domain.postlike.repository.PostLikeRepository;
-import couch.camping.exception.CustomException;
-import couch.camping.exception.ErrorCode;
-import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
-import org.springframework.security.core.userdetails.UserDetailsService;
-import org.springframework.security.core.userdetails.UsernameNotFoundException;
-import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
 
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.List;
-import java.util.Optional;
+public interface PostService {
 
-@Service
-@RequiredArgsConstructor
-@Transactional(readOnly = true)
-public class PostService {
+    PostWriteResponseDto writePost(PostWriteRequestDto postWriteRequestDto, Member member);
 
-    private final PostRepository postRepository;
-    private final PostImageRepository postImageRepository;
-    private final PostLikeRepository postLikeRepository;
-    private final UserDetailsService userDetailsService;
-    private final CommentRepository commentRepository;
+    PostEditResponseDto editPost(Long postId, Member member, PostEditRequestDto postEditRequestDto);
 
-    @Transactional
-    public PostWriteResponseDto writePost(PostWriteRequestDto postWriteRequestDto, Member member) {
-        List<String> postTypeList = Arrays.asList("free", "picture", "question");
+    void likePost(Long postId, Member member);
 
-        if (!postTypeList.contains(postWriteRequestDto.getPostType()))
-            throw new CustomException(ErrorCode.BAD_REQUEST_PARAM, "postType 의 값은 free, picture, question 만 가능합니다.");
+    PostRetrieveResponseDto retrievePost(Long postId, String header);
 
-        Post post = Post.builder()
-                .content(postWriteRequestDto.getContent())
-                .postType(postWriteRequestDto.getPostType())
-                .member(member)
-                .build();
+    Page<PostRetrieveResponseDto> retrieveAllPost(String postType, Pageable pageable, String header);
 
-        for (String imgUrl : postWriteRequestDto.getImgUrlList()) {
-            PostImage postImage = new PostImage(member, post, imgUrl);
-            post.getPostImageList().add(postImage);
-        }
+    Page<PostRetrieveResponseDto> retrieveAllBestPost(Pageable pageable);
 
-        Post savePost = postRepository.save(post);
+    void deletePost(Long postId, Member member);
 
-        return new PostWriteResponseDto(savePost, savePost.getPostImageList());
-    }
-
-    @Transactional
-    public PostEditResponseDto editPost(Long postId, Member member, PostEditRequestDto postEditRequestDto) {
-        Post findPost = postRepository.findById(postId)
-                .orElseThrow(() -> {
-                    throw new CustomException(ErrorCode.NOT_FOUND_POST, "게시글 ID 에 맞는 게시글이 없습니다.");
-                });
-
-        if (findPost.getMember() != member) {
-            throw new CustomException(ErrorCode.FORBIDDEN_MEMBER, "해당 회원의 게시글이 아닙니다.");
-        }
-
-        findPost.editPost(postEditRequestDto.getContent(), postEditRequestDto.getPostType());
-
-        //벌크 연산, 영속성 컨텍스트 초기화
-        postImageRepository.deleteByPostId(postId);
-
-        List<PostImage> postImageList = new ArrayList<>();
-        for (String imgUrl : postEditRequestDto.getImgUrlList()) {
-            PostImage postImage = PostImage.builder()
-                    .post(findPost)
-                    .member(member)
-                    .imgUrl(imgUrl)
-                    .build();
-            postImageList.add(postImage);
-        }
-        postImageRepository.saveAll(postImageList);
-
-        return new PostEditResponseDto(findPost, postImageList);
-
-    }
-
-    @Transactional
-    public void likePost(Long postId, Member member) {
-        Post findPost = postRepository.findById(postId)
-                .orElseThrow(() -> {
-                    throw new CustomException(ErrorCode.NOT_FOUND_POST, "게시글 ID 에 맞는 게시글이 없습니다.");
-                });
-
-        Optional<PostLike> optionalPostLike = postLikeRepository.findByMemberIdAndPostId(member.getId(), postId);
-
-        if (optionalPostLike.isPresent()) {//좋아요를 눌렀을 때
-            findPost.decreaseLikeCnt();
-            postLikeRepository.deleteById(optionalPostLike.get().getId());
-        } else {//좋아요를 누르지 않았을 때
-            findPost.increaseLikeCnt();
-            PostLike postLike = PostLike.builder()
-                    .post(findPost)
-                    .member(member)
-                    .build();
-
-            postLikeRepository.save(postLike);
-        }
-    }
-
-    public PostRetrieveResponseDto retrievePost(Long postId, String header) {
-        Post findPost = postRepository.findByIdWithFetchJoinMember(postId)
-                .orElseThrow(() -> {
-                    throw new CustomException(ErrorCode.NOT_FOUND_POST, "게시글 ID 에 맞는 게시글이 없습니다.");
-                });
-
-        if (header == null) {//비로그인
-            return new PostRetrieveResponseDto(findPost, findPost.getCommentList().size(), findPost.getPostImageList());
-        } else {//로그인
-            Member member;
-            try {
-                member = (Member)userDetailsService.loadUserByUsername(header);
-            } catch (UsernameNotFoundException e) {
-                throw new CustomException(ErrorCode.NOT_FOUND_MEMBER, "토큰에 해당하는 회원이 존재하지 않습니다.");
-            }
-            Optional<PostLike> optionalPostLike = postLikeRepository.findByMemberIdAndPostId(member.getId(), postId);
-            return new PostRetrieveLoginResponseDto(findPost, findPost.getCommentList().size(), findPost.getPostImageList(), optionalPostLike.isPresent());
-        }
-    }
-
-    public Page<PostRetrieveResponseDto> retrieveAllPost(String postType, Pageable pageable, String header) {
-        List<String> postTypeList = Arrays.asList("all", "free", "picture", "question");
-
-        if (!postTypeList.contains(postType)) {
-            throw new CustomException(ErrorCode.BAD_REQUEST_PARAM, "쿼리스트링 postType 의 값은 all, free, picture, question 만 가능합니다.");
-        }
-        if (header == null) {
-            return postRepository.findAllByIdWithFetchJoinMemberPaging(postType, pageable)
-                    .map(post -> new PostRetrieveResponseDto(post, post.getCommentList().size(), post.getPostImageList()));
-        } else {
-            Member member;
-            try {
-                member = (Member)userDetailsService.loadUserByUsername(header);
-            } catch (UsernameNotFoundException e) {
-                throw new CustomException(ErrorCode.NOT_FOUND_MEMBER, "토큰에 해당하는 회원이 존재하지 않습니다.");
-            }
-
-            return postRepository.findAllByIdWithFetchJoinMemberPaging(postType, pageable)
-                    .map(post -> {
-                        List<PostLike> postLikeList = post.getPostLikeList();
-                        for (PostLike postLike : postLikeList) {
-                            if (postLike.getMember() == member) {
-                                return new PostRetrieveLoginResponseDto(post, post.getCommentList().size(), post.getPostImageList(), true);
-                            }
-                        }
-                        return new PostRetrieveLoginResponseDto(post, post.getCommentList().size(), post.getPostImageList(), false);
-                    });
-        }
-    }
-
-    public Page<PostRetrieveResponseDto> retrieveAllBestPost(Pageable pageable) {
-        return postRepository.findAllBestPost(pageable)
-                .map(post -> new PostRetrieveResponseDto(post, post.getCommentList().size(), post.getPostImageList()));
-    }
-
-    @Transactional
-    public void deletePost(Long postId, Member member) {
-        Post findPost = postRepository.findById(postId)
-                .orElseThrow(() -> {
-                    throw new CustomException(ErrorCode.NOT_FOUND_POST, "게시글 ID 에 맞는 게시글이 없습니다.");
-                });
-        
-        if (findPost.getMember() == member) {
-            throw new CustomException(ErrorCode.FORBIDDEN_MEMBER, "해당 회원의 게시글이 아닙니다.");
-        }
-
-        postRepository.deleteById(postId);
-    }
 }

--- a/src/main/java/couch/camping/domain/post/service/PostServiceImpl.java
+++ b/src/main/java/couch/camping/domain/post/service/PostServiceImpl.java
@@ -1,0 +1,201 @@
+package couch.camping.domain.post.service;
+
+import com.google.firebase.auth.FirebaseAuth;
+import com.google.firebase.auth.FirebaseAuthException;
+import com.google.firebase.auth.FirebaseToken;
+import couch.camping.controller.post.dto.request.PostEditRequestDto;
+import couch.camping.controller.post.dto.request.PostWriteRequestDto;
+import couch.camping.controller.post.dto.response.PostEditResponseDto;
+import couch.camping.controller.post.dto.response.PostRetrieveLoginResponseDto;
+import couch.camping.controller.post.dto.response.PostRetrieveResponseDto;
+import couch.camping.controller.post.dto.response.PostWriteResponseDto;
+import couch.camping.domain.member.entity.Member;
+import couch.camping.domain.post.entity.Post;
+import couch.camping.domain.post.repository.PostRepository;
+import couch.camping.domain.postimage.entity.PostImage;
+import couch.camping.domain.postimage.repository.PostImageRepository;
+import couch.camping.domain.postlike.entity.PostLike;
+import couch.camping.domain.postlike.repository.PostLikeRepository;
+import couch.camping.exception.CustomException;
+import couch.camping.exception.ErrorCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Profile;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
+
+@Profile("prod")
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class PostServiceImpl implements PostService {
+
+    private final PostRepository postRepository;
+    private final PostImageRepository postImageRepository;
+    private final PostLikeRepository postLikeRepository;
+    private final UserDetailsService userDetailsService;
+    private final FirebaseAuth firebaseAuth;
+
+    @Transactional
+    @Override
+    public PostWriteResponseDto writePost(PostWriteRequestDto postWriteRequestDto, Member member) {
+        List<String> postTypeList = Arrays.asList("free", "picture", "question");
+
+        if (!postTypeList.contains(postWriteRequestDto.getPostType()))
+            throw new CustomException(ErrorCode.BAD_REQUEST_PARAM, "postType 의 값은 free, picture, question 만 가능합니다.");
+
+        Post post = Post.builder()
+                .content(postWriteRequestDto.getContent())
+                .postType(postWriteRequestDto.getPostType())
+                .member(member)
+                .build();
+
+        for (String imgUrl : postWriteRequestDto.getImgUrlList()) {
+            PostImage postImage = new PostImage(member, post, imgUrl);
+            post.getPostImageList().add(postImage);
+        }
+
+        Post savePost = postRepository.save(post);
+
+        return new PostWriteResponseDto(savePost, savePost.getPostImageList());
+    }
+
+    @Transactional
+    @Override
+    public PostEditResponseDto editPost(Long postId, Member member, PostEditRequestDto postEditRequestDto) {
+        Post findPost = postRepository.findById(postId)
+                .orElseThrow(() -> {
+                    throw new CustomException(ErrorCode.NOT_FOUND_POST, "게시글 ID 에 맞는 게시글이 없습니다.");
+                });
+
+        if (findPost.getMember() != member) {
+            throw new CustomException(ErrorCode.FORBIDDEN_MEMBER, "해당 회원의 게시글이 아닙니다.");
+        }
+
+        findPost.editPost(postEditRequestDto.getContent(), postEditRequestDto.getPostType());
+
+        //벌크 연산, 영속성 컨텍스트 초기화
+        postImageRepository.deleteByPostId(postId);
+
+        List<PostImage> postImageList = new ArrayList<>();
+        for (String imgUrl : postEditRequestDto.getImgUrlList()) {
+            PostImage postImage = PostImage.builder()
+                    .post(findPost)
+                    .member(member)
+                    .imgUrl(imgUrl)
+                    .build();
+            postImageList.add(postImage);
+        }
+        postImageRepository.saveAll(postImageList);
+
+        return new PostEditResponseDto(findPost, postImageList);
+
+    }
+
+    @Transactional
+    @Override
+    public void likePost(Long postId, Member member) {
+        Post findPost = postRepository.findById(postId)
+                .orElseThrow(() -> {
+                    throw new CustomException(ErrorCode.NOT_FOUND_POST, "게시글 ID 에 맞는 게시글이 없습니다.");
+                });
+
+        Optional<PostLike> optionalPostLike = postLikeRepository.findByMemberIdAndPostId(member.getId(), postId);
+
+        if (optionalPostLike.isPresent()) {//좋아요를 눌렀을 때
+            findPost.decreaseLikeCnt();
+            postLikeRepository.deleteById(optionalPostLike.get().getId());
+        } else {//좋아요를 누르지 않았을 때
+            findPost.increaseLikeCnt();
+            PostLike postLike = PostLike.builder()
+                    .post(findPost)
+                    .member(member)
+                    .build();
+
+            postLikeRepository.save(postLike);
+        }
+    }
+
+    @Override
+    public PostRetrieveResponseDto retrievePost(Long postId, String header) {
+        Post findPost = postRepository.findByIdWithFetchJoinMember(postId)
+                .orElseThrow(() -> {
+                    throw new CustomException(ErrorCode.NOT_FOUND_POST, "게시글 ID 에 맞는 게시글이 없습니다.");
+                });
+
+        if (header == null) {//비로그인
+            return new PostRetrieveResponseDto(findPost, findPost.getCommentList().size(), findPost.getPostImageList());
+        } else {//로그인
+            Member member;
+            try {
+                FirebaseToken decodedToken = firebaseAuth.verifyIdToken(header);
+                member = (Member)userDetailsService.loadUserByUsername(decodedToken.getUid());
+            } catch (UsernameNotFoundException | FirebaseAuthException | IllegalArgumentException e) {
+                throw new CustomException(ErrorCode.NOT_FOUND_MEMBER, "토큰에 해당하는 회원이 존재하지 않습니다.");
+            }
+            Optional<PostLike> optionalPostLike = postLikeRepository.findByMemberIdAndPostId(member.getId(), postId);
+            return new PostRetrieveLoginResponseDto(findPost, findPost.getCommentList().size(), findPost.getPostImageList(), optionalPostLike.isPresent());
+        }
+    }
+
+    @Override
+    public Page<PostRetrieveResponseDto> retrieveAllPost(String postType, Pageable pageable, String header) {
+        List<String> postTypeList = Arrays.asList("all", "free", "picture", "question");
+
+        if (!postTypeList.contains(postType)) {
+            throw new CustomException(ErrorCode.BAD_REQUEST_PARAM, "쿼리스트링 postType 의 값은 all, free, picture, question 만 가능합니다.");
+        }
+        if (header == null) {
+            return postRepository.findAllByIdWithFetchJoinMemberPaging(postType, pageable)
+                    .map(post -> new PostRetrieveResponseDto(post, post.getCommentList().size(), post.getPostImageList()));
+        } else {
+            Member member;
+            try {
+                FirebaseToken decodedToken = firebaseAuth.verifyIdToken(header);
+                member = (Member)userDetailsService.loadUserByUsername(decodedToken.getUid());
+            } catch (UsernameNotFoundException | FirebaseAuthException | IllegalArgumentException e) {
+                throw new CustomException(ErrorCode.NOT_FOUND_MEMBER, "토큰에 해당하는 회원이 존재하지 않습니다.");
+            }
+
+            return postRepository.findAllByIdWithFetchJoinMemberPaging(postType, pageable)
+                    .map(post -> {
+                        List<PostLike> postLikeList = post.getPostLikeList();
+                        for (PostLike postLike : postLikeList) {
+                            if (postLike.getMember() == member) {
+                                return new PostRetrieveLoginResponseDto(post, post.getCommentList().size(), post.getPostImageList(), true);
+                            }
+                        }
+                        return new PostRetrieveLoginResponseDto(post, post.getCommentList().size(), post.getPostImageList(), false);
+                    });
+        }
+    }
+
+    @Override
+    public Page<PostRetrieveResponseDto> retrieveAllBestPost(Pageable pageable) {
+        return postRepository.findAllBestPost(pageable)
+                .map(post -> new PostRetrieveResponseDto(post, post.getCommentList().size(), post.getPostImageList()));
+    }
+
+    @Transactional
+    @Override
+    public void deletePost(Long postId, Member member) {
+        Post findPost = postRepository.findById(postId)
+                .orElseThrow(() -> {
+                    throw new CustomException(ErrorCode.NOT_FOUND_POST, "게시글 ID 에 맞는 게시글이 없습니다.");
+                });
+        
+        if (findPost.getMember() == member) {
+            throw new CustomException(ErrorCode.FORBIDDEN_MEMBER, "해당 회원의 게시글이 아닙니다.");
+        }
+
+        postRepository.deleteById(postId);
+    }
+}

--- a/src/main/java/couch/camping/domain/post/service/PostServiceLocalImpl.java
+++ b/src/main/java/couch/camping/domain/post/service/PostServiceLocalImpl.java
@@ -1,0 +1,195 @@
+package couch.camping.domain.post.service;
+
+import couch.camping.controller.post.dto.request.PostEditRequestDto;
+import couch.camping.controller.post.dto.request.PostWriteRequestDto;
+import couch.camping.controller.post.dto.response.PostEditResponseDto;
+import couch.camping.controller.post.dto.response.PostRetrieveLoginResponseDto;
+import couch.camping.controller.post.dto.response.PostRetrieveResponseDto;
+import couch.camping.controller.post.dto.response.PostWriteResponseDto;
+import couch.camping.domain.member.entity.Member;
+import couch.camping.domain.post.entity.Post;
+import couch.camping.domain.post.repository.PostRepository;
+import couch.camping.domain.postimage.entity.PostImage;
+import couch.camping.domain.postimage.repository.PostImageRepository;
+import couch.camping.domain.postlike.entity.PostLike;
+import couch.camping.domain.postlike.repository.PostLikeRepository;
+import couch.camping.exception.CustomException;
+import couch.camping.exception.ErrorCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Profile;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
+
+@Profile("local")
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class PostServiceLocalImpl implements PostService {
+
+    private final PostRepository postRepository;
+    private final PostImageRepository postImageRepository;
+    private final PostLikeRepository postLikeRepository;
+    private final UserDetailsService userDetailsService;
+
+    @Transactional
+    @Override
+    public PostWriteResponseDto writePost(PostWriteRequestDto postWriteRequestDto, Member member) {
+        List<String> postTypeList = Arrays.asList("free", "picture", "question");
+
+        if (!postTypeList.contains(postWriteRequestDto.getPostType()))
+            throw new CustomException(ErrorCode.BAD_REQUEST_PARAM, "postType 의 값은 free, picture, question 만 가능합니다.");
+
+        Post post = Post.builder()
+                .content(postWriteRequestDto.getContent())
+                .postType(postWriteRequestDto.getPostType())
+                .member(member)
+                .build();
+
+        for (String imgUrl : postWriteRequestDto.getImgUrlList()) {
+            PostImage postImage = new PostImage(member, post, imgUrl);
+            post.getPostImageList().add(postImage);
+        }
+
+        Post savePost = postRepository.save(post);
+
+        return new PostWriteResponseDto(savePost, savePost.getPostImageList());
+    }
+
+    @Transactional
+    @Override
+    public PostEditResponseDto editPost(Long postId, Member member, PostEditRequestDto postEditRequestDto) {
+        Post findPost = postRepository.findById(postId)
+                .orElseThrow(() -> {
+                    throw new CustomException(ErrorCode.NOT_FOUND_POST, "게시글 ID 에 맞는 게시글이 없습니다.");
+                });
+
+        if (findPost.getMember() != member) {
+            throw new CustomException(ErrorCode.FORBIDDEN_MEMBER, "해당 회원의 게시글이 아닙니다.");
+        }
+
+        findPost.editPost(postEditRequestDto.getContent(), postEditRequestDto.getPostType());
+
+        //벌크 연산, 영속성 컨텍스트 초기화
+        postImageRepository.deleteByPostId(postId);
+
+        List<PostImage> postImageList = new ArrayList<>();
+        for (String imgUrl : postEditRequestDto.getImgUrlList()) {
+            PostImage postImage = PostImage.builder()
+                    .post(findPost)
+                    .member(member)
+                    .imgUrl(imgUrl)
+                    .build();
+            postImageList.add(postImage);
+        }
+        postImageRepository.saveAll(postImageList);
+
+        return new PostEditResponseDto(findPost, postImageList);
+
+    }
+
+    @Transactional
+    @Override
+    public void likePost(Long postId, Member member) {
+        Post findPost = postRepository.findById(postId)
+                .orElseThrow(() -> {
+                    throw new CustomException(ErrorCode.NOT_FOUND_POST, "게시글 ID 에 맞는 게시글이 없습니다.");
+                });
+
+        Optional<PostLike> optionalPostLike = postLikeRepository.findByMemberIdAndPostId(member.getId(), postId);
+
+        if (optionalPostLike.isPresent()) {//좋아요를 눌렀을 때
+            findPost.decreaseLikeCnt();
+            postLikeRepository.deleteById(optionalPostLike.get().getId());
+        } else {//좋아요를 누르지 않았을 때
+            findPost.increaseLikeCnt();
+            PostLike postLike = PostLike.builder()
+                    .post(findPost)
+                    .member(member)
+                    .build();
+
+            postLikeRepository.save(postLike);
+        }
+    }
+
+    @Override
+    public PostRetrieveResponseDto retrievePost(Long postId, String header) {
+        Post findPost = postRepository.findByIdWithFetchJoinMember(postId)
+                .orElseThrow(() -> {
+                    throw new CustomException(ErrorCode.NOT_FOUND_POST, "게시글 ID 에 맞는 게시글이 없습니다.");
+                });
+
+        if (header == null) {//비로그인
+            return new PostRetrieveResponseDto(findPost, findPost.getCommentList().size(), findPost.getPostImageList());
+        } else {//로그인
+            Member member;
+            try {
+                member = (Member)userDetailsService.loadUserByUsername(header);
+            } catch (UsernameNotFoundException e) {
+                throw new CustomException(ErrorCode.NOT_FOUND_MEMBER, "토큰에 해당하는 회원이 존재하지 않습니다.");
+            }
+            Optional<PostLike> optionalPostLike = postLikeRepository.findByMemberIdAndPostId(member.getId(), postId);
+            return new PostRetrieveLoginResponseDto(findPost, findPost.getCommentList().size(), findPost.getPostImageList(), optionalPostLike.isPresent());
+        }
+    }
+
+    @Override
+    public Page<PostRetrieveResponseDto> retrieveAllPost(String postType, Pageable pageable, String header) {
+        List<String> postTypeList = Arrays.asList("all", "free", "picture", "question");
+
+        if (!postTypeList.contains(postType)) {
+            throw new CustomException(ErrorCode.BAD_REQUEST_PARAM, "쿼리스트링 postType 의 값은 all, free, picture, question 만 가능합니다.");
+        }
+        if (header == null) {
+            return postRepository.findAllByIdWithFetchJoinMemberPaging(postType, pageable)
+                    .map(post -> new PostRetrieveResponseDto(post, post.getCommentList().size(), post.getPostImageList()));
+        } else {
+            Member member;
+            try {
+                member = (Member)userDetailsService.loadUserByUsername(header);
+            } catch (UsernameNotFoundException e) {
+                throw new CustomException(ErrorCode.NOT_FOUND_MEMBER, "토큰에 해당하는 회원이 존재하지 않습니다.");
+            }
+
+            return postRepository.findAllByIdWithFetchJoinMemberPaging(postType, pageable)
+                    .map(post -> {
+                        List<PostLike> postLikeList = post.getPostLikeList();
+                        for (PostLike postLike : postLikeList) {
+                            if (postLike.getMember() == member) {
+                                return new PostRetrieveLoginResponseDto(post, post.getCommentList().size(), post.getPostImageList(), true);
+                            }
+                        }
+                        return new PostRetrieveLoginResponseDto(post, post.getCommentList().size(), post.getPostImageList(), false);
+                    });
+        }
+    }
+
+    @Override
+    public Page<PostRetrieveResponseDto> retrieveAllBestPost(Pageable pageable) {
+        return postRepository.findAllBestPost(pageable)
+                .map(post -> new PostRetrieveResponseDto(post, post.getCommentList().size(), post.getPostImageList()));
+    }
+
+    @Transactional
+    @Override
+    public void deletePost(Long postId, Member member) {
+        Post findPost = postRepository.findById(postId)
+                .orElseThrow(() -> {
+                    throw new CustomException(ErrorCode.NOT_FOUND_POST, "게시글 ID 에 맞는 게시글이 없습니다.");
+                });
+        
+        if (findPost.getMember() == member) {
+            throw new CustomException(ErrorCode.FORBIDDEN_MEMBER, "해당 회원의 게시글이 아닙니다.");
+        }
+
+        postRepository.deleteById(postId);
+    }
+}


### PR DESCRIPTION
<br/>

## 해당 이슈 📎

- issue title #87

  <br/>

## 변경 사항 🛠
- 댓글 컨트롤러에 의존적인 컨트롤러를 PostCommentController.class 에 작성

<br/>

## 리뷰어 참고 사항 🙋‍♀️
- 게시글 도메인에 의존적인 handlerMethod 를 PostCommentController 에 작성했습니다.
<br/>
