### PR TITLE
REFACTOR: 게시글 댓글 전체 조회 API 페이징 처리 에러 수정

### DIFF
--- a/src/main/java/couch/camping/controller/post/PostCommentController.java
+++ b/src/main/java/couch/camping/controller/post/PostCommentController.java
@@ -25,8 +25,8 @@ public class PostCommentController {
     private final CommentService commentService;
 
     //게시글의 댓글 전체 조회
-    @ApiOperation(value = "커뮤니티 댓글 전체 조회 API", notes = "게시글 ID를 통해 댓글 전체를 조회합니다.")
-    @GetMapping("/posts/{postId}/comment")
+    @ApiOperation(value = "커뮤니티 댓글 전체 조회 API", notes = "게시글 ID를 통해 댓글 전체를 조회합니다. 쿼리스트링 예시(?page=0&size=10)")
+    @GetMapping("/posts/{postId}/comments")
     public ResponseEntity<Page<CommentRetrieveResponseDto>> retrieveAllComment(@ApiParam(value = "게시글 ID", required = true) @PathVariable Long postId,
                                                                                HttpServletRequest request,
                                                                                Pageable pageable){
@@ -36,7 +36,7 @@ public class PostCommentController {
 
     //댓글 작성
     @ApiOperation(value = "커뮤니티 댓글 작성 API", notes = "게시글 ID를 통해 해당 게시글에 댓글을 작성합니다.")
-    @PostMapping("/posts/{postId}/comment") //이게 코멘트 컨트롤러에 있는 게 맞나?
+    @PostMapping("/posts/{postId}/comments")
     public ResponseEntity<CommentWriteResponseDto> writeComment(@RequestBody CommentWriteRequestDto commentWriteRequestDto,
                                                                 @ApiParam(value = "게시글 ID", required = true) @PathVariable Long postId,
                                                                 Authentication authentication){

--- a/src/main/java/couch/camping/controller/post/PostController.java
+++ b/src/main/java/couch/camping/controller/post/PostController.java
@@ -43,7 +43,7 @@ public class PostController {
 
     //게시글 전체 조회
     @GetMapping("")
-    @ApiOperation(value = "커뮤니티 게시글 전체 조회 API", notes = "커뮤니티에서 모든 게시글을 조회합니다.")
+    @ApiOperation(value = "커뮤니티 게시글 전체 조회 API", notes = "커뮤니티에서 모든 게시글을 조회합니다. 쿼리스트링 예시(?page=0&size=10)")
     public ResponseEntity retrieveAllPost(Pageable pageable, @ApiParam(value = "게시글 분류", required = false) @RequestParam(defaultValue = "all") String postType,
                                           HttpServletRequest request) {
         String header = RequestUtil.getAuthorizationToken(request);
@@ -71,7 +71,7 @@ public class PostController {
     
     //베스트 게시글 조회
     @GetMapping("/best")
-    @ApiOperation(value = "커뮤니티 베스트 게시글 조회 API", notes = "게시글 중 좋아요가 가장 많은 게시글을 불러옵니다.")
+    @ApiOperation(value = "커뮤니티 베스트 게시글 조회 API", notes = "게시글 중 좋아요가 가장 많은 게시글을 불러옵니다. 쿼리스트링 예시(?page=0&size=10)")
     public ResponseEntity retrieveAllBestPost(Pageable pageable) {
         return ResponseEntity.ok(postService.retrieveAllBestPost(pageable));
     }

--- a/src/main/java/couch/camping/domain/comment/repository/CommentCustomRepositoryImpl.java
+++ b/src/main/java/couch/camping/domain/comment/repository/CommentCustomRepositoryImpl.java
@@ -23,8 +23,11 @@ public class CommentCustomRepositoryImpl implements CommentCustomRepository {
     public Page<Comment> findAllByIdWithFetchJoinMemberPaging(Long postId, Pageable pageable) {
         List<Comment> commentList = queryFactory
                 .selectFrom(comment)
-                .where(comment.post.id.eq(postId))
                 .join(comment.member, member).fetchJoin()
+                .where(comment.post.id.eq(postId))
+                .offset(pageable.getOffset())
+                .limit(pageable.getPageSize())
+                .orderBy(comment.createdDate.asc())
                 .fetch();
 
         Long total = queryFactory.select(comment.count())
@@ -40,8 +43,8 @@ public class CommentCustomRepositoryImpl implements CommentCustomRepository {
 
         Comment comment = queryFactory
                 .selectFrom(QComment.comment)
-                .where(QComment.comment.id.eq(postId))
                 .join(QComment.comment.member, member).fetchJoin()
+                .where(QComment.comment.id.eq(postId))
                 .fetchOne();
 
         return Optional.ofNullable(comment);


### PR DESCRIPTION
<br/>

## 해당 이슈 📎

- issue title #113
- 게시글 댓글 조회 API 페이징 시 쿼리 에러

  <br/>

## 변경 사항 🛠
- 게시글 댓글 조회 쿼리 페이징 적용 및 쿼리 수정
- postCommentController 의 url 엔드포인트를 /comment -> /comments
<br/>

## 리뷰어 참고 사항 🙋‍♀️
- API 개발 후 테스트를 해주세요!
- 게시글 전체 댓글 조회 쿼리에 페이징이 적용되어 있지 않아 수정했습니다.
<br/>
