### PR TITLE
REFACTOR: post, comment 엔티티 lastModifedBy 필드 제거 후 lastModifedDate 수동 업데이트

### DIFF
--- a/build/generated/querydsl/couch/camping/domain/comment/entity/QComment.java
+++ b/build/generated/querydsl/couch/camping/domain/comment/entity/QComment.java
@@ -22,25 +22,17 @@ public class QComment extends EntityPathBase<Comment> {
 
     public static final QComment comment = new QComment("comment");
 
-    public final couch.camping.domain.base.QBaseEntity _super = new couch.camping.domain.base.QBaseEntity(this);
-
     public final ListPath<couch.camping.domain.commentlike.entity.CommentLike, couch.camping.domain.commentlike.entity.QCommentLike> commentLikeList = this.<couch.camping.domain.commentlike.entity.CommentLike, couch.camping.domain.commentlike.entity.QCommentLike>createList("commentLikeList", couch.camping.domain.commentlike.entity.CommentLike.class, couch.camping.domain.commentlike.entity.QCommentLike.class, PathInits.DIRECT2);
 
     public final StringPath content = createString("content");
 
-    //inherited
-    public final StringPath createdBy = _super.createdBy;
+    public final StringPath createdBy = createString("createdBy");
 
-    //inherited
-    public final DateTimePath<java.time.LocalDateTime> createdDate = _super.createdDate;
+    public final DateTimePath<java.time.LocalDateTime> createdDate = createDateTime("createdDate", java.time.LocalDateTime.class);
 
     public final NumberPath<Long> id = createNumber("id", Long.class);
 
-    //inherited
-    public final StringPath lastModifiedBy = _super.lastModifiedBy;
-
-    //inherited
-    public final DateTimePath<java.time.LocalDateTime> lastModifiedDate = _super.lastModifiedDate;
+    public final DateTimePath<java.time.LocalDateTime> lastModifiedDate = createDateTime("lastModifiedDate", java.time.LocalDateTime.class);
 
     public final NumberPath<Integer> likeCnt = createNumber("likeCnt", Integer.class);
 

--- a/build/generated/querydsl/couch/camping/domain/post/entity/QPost.java
+++ b/build/generated/querydsl/couch/camping/domain/post/entity/QPost.java
@@ -22,27 +22,19 @@ public class QPost extends EntityPathBase<Post> {
 
     public static final QPost post = new QPost("post");
 
-    public final couch.camping.domain.base.QBaseEntity _super = new couch.camping.domain.base.QBaseEntity(this);
-
     public final NumberPath<Integer> commentCnt = createNumber("commentCnt", Integer.class);
 
     public final ListPath<couch.camping.domain.comment.entity.Comment, couch.camping.domain.comment.entity.QComment> commentList = this.<couch.camping.domain.comment.entity.Comment, couch.camping.domain.comment.entity.QComment>createList("commentList", couch.camping.domain.comment.entity.Comment.class, couch.camping.domain.comment.entity.QComment.class, PathInits.DIRECT2);
 
     public final StringPath content = createString("content");
 
-    //inherited
-    public final StringPath createdBy = _super.createdBy;
+    public final StringPath createdBy = createString("createdBy");
 
-    //inherited
-    public final DateTimePath<java.time.LocalDateTime> createdDate = _super.createdDate;
+    public final DateTimePath<java.time.LocalDateTime> createdDate = createDateTime("createdDate", java.time.LocalDateTime.class);
 
     public final NumberPath<Long> id = createNumber("id", Long.class);
 
-    //inherited
-    public final StringPath lastModifiedBy = _super.lastModifiedBy;
-
-    //inherited
-    public final DateTimePath<java.time.LocalDateTime> lastModifiedDate = _super.lastModifiedDate;
+    public final DateTimePath<java.time.LocalDateTime> lastModifiedDate = createDateTime("lastModifiedDate", java.time.LocalDateTime.class);
 
     public final NumberPath<Integer> likeCnt = createNumber("likeCnt", Integer.class);
 

--- a/src/main/java/couch/camping/domain/comment/entity/Comment.java
+++ b/src/main/java/couch/camping/domain/comment/entity/Comment.java
@@ -1,21 +1,28 @@
 package couch.camping.domain.comment.entity;
 
-import couch.camping.domain.base.BaseEntity;
 import couch.camping.domain.commentlike.entity.CommentLike;
 import couch.camping.domain.member.entity.Member;
 import couch.camping.domain.post.entity.Post;
-import lombok.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.CreatedBy;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 import javax.persistence.*;
+import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 
+@EntityListeners(AuditingEntityListener.class)
 @Entity
 @NoArgsConstructor
 @AllArgsConstructor
 @Builder
 @Getter
-public class Comment extends BaseEntity {
+public class Comment {
 
     @Id @GeneratedValue
     @Column(name = "comment_id")
@@ -38,8 +45,19 @@ public class Comment extends BaseEntity {
 
     private int likeCnt;
 
+    @Column(updatable = false)
+    @CreatedDate
+    private LocalDateTime createdDate;
+
+    private LocalDateTime lastModifiedDate;
+
+    @CreatedBy
+    @Column(updatable = false)
+    private String createdBy;
+
     public void editComment(String content){
         this.content = content;
+        this.lastModifiedDate = LocalDateTime.now();
     }
 
     public void increaseLikeCnt() {

--- a/src/main/java/couch/camping/domain/comment/service/CommentServiceImpl.java
+++ b/src/main/java/couch/camping/domain/comment/service/CommentServiceImpl.java
@@ -29,6 +29,7 @@ import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 
@@ -57,6 +58,7 @@ public class CommentServiceImpl implements CommentService {
                 .content(commentWriteRequestDto.getContent())
                 .member(member)
                 .post(findPost)
+                .lastModifiedDate(LocalDateTime.now())
                 .build();
 
         Comment saveComment = commentRepository.save(comment);

--- a/src/main/java/couch/camping/domain/comment/service/CommentServiceLocalImpl.java
+++ b/src/main/java/couch/camping/domain/comment/service/CommentServiceLocalImpl.java
@@ -26,6 +26,7 @@ import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 
@@ -53,6 +54,7 @@ public class CommentServiceLocalImpl implements CommentService {
                 .content(commentWriteRequestDto.getContent())
                 .member(member)
                 .post(findPost)
+                .lastModifiedDate(LocalDateTime.now())
                 .build();
 
         Comment saveComment = commentRepository.save(comment);

--- a/src/main/java/couch/camping/domain/post/entity/Post.java
+++ b/src/main/java/couch/camping/domain/post/entity/Post.java
@@ -1,6 +1,5 @@
 package couch.camping.domain.post.entity;
 
-import couch.camping.domain.base.BaseEntity;
 import couch.camping.domain.comment.entity.Comment;
 import couch.camping.domain.member.entity.Member;
 import couch.camping.domain.postimage.entity.PostImage;
@@ -9,17 +8,22 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.CreatedBy;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 import javax.persistence.*;
+import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 
+@EntityListeners(AuditingEntityListener.class)
 @Entity
 @NoArgsConstructor
 @AllArgsConstructor
 @Builder
 @Getter
-public class Post extends BaseEntity {
+public class Post {
 
     @Id @GeneratedValue
     @Column(name = "post_id")
@@ -52,10 +56,21 @@ public class Post extends BaseEntity {
 
     private int commentCnt;
 
+    @Column(updatable = false)
+    @CreatedDate
+    private LocalDateTime createdDate;
+
+    private LocalDateTime lastModifiedDate;
+
+    @CreatedBy
+    @Column(updatable = false)
+    private String createdBy;
+
     public void editPost(String title, String content, String hashTag) {
         this.title = title;
         this.content = content;
         this.postType = hashTag;
+        this.lastModifiedDate = LocalDateTime.now();
     }
 
     public void increaseLikeCnt() {

--- a/src/main/java/couch/camping/domain/post/service/PostServiceImpl.java
+++ b/src/main/java/couch/camping/domain/post/service/PostServiceImpl.java
@@ -29,6 +29,7 @@ import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -59,6 +60,7 @@ public class PostServiceImpl implements PostService {
                 .title(postWriteRequestDto.getTitle())
                 .content(postWriteRequestDto.getContent())
                 .postType(postWriteRequestDto.getPostType())
+                .lastModifiedDate(LocalDateTime.now())
                 .member(member)
                 .build();
 

--- a/src/main/java/couch/camping/domain/post/service/PostServiceLocalImpl.java
+++ b/src/main/java/couch/camping/domain/post/service/PostServiceLocalImpl.java
@@ -26,6 +26,7 @@ import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -55,6 +56,7 @@ public class PostServiceLocalImpl implements PostService {
                 .title(postWriteRequestDto.getTitle())
                 .content(postWriteRequestDto.getContent())
                 .postType(postWriteRequestDto.getPostType())
+                .lastModifiedDate(LocalDateTime.now())
                 .member(member)
                 .build();
 

--- a/src/test/java/couch/camping/common/BaseControllerTest.java
+++ b/src/test/java/couch/camping/common/BaseControllerTest.java
@@ -6,10 +6,12 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.transaction.annotation.Transactional;
 
 
+@TestPropertySource(properties = {"spring.config.location=classpath:application-test.yml"})
 @ActiveProfiles("local")
 @Disabled
 @Transactional

--- a/src/test/java/couch/camping/controller/member/MemberControllerTest.java
+++ b/src/test/java/couch/camping/controller/member/MemberControllerTest.java
@@ -90,6 +90,7 @@ class MemberControllerTest extends BaseControllerTest {
     @Test
     @DisplayName("로그인 테스트")
     void memberLoginTest() throws Exception {
+        //TODO 생성 메서드 개발
         memberService.register(uid, name, email, nickname, imgUrl);
 
         ResultActions resultActions = mockMvc.perform(
@@ -113,6 +114,7 @@ class MemberControllerTest extends BaseControllerTest {
     @Test
     @DisplayName("닉네임 수정 테스트")
     void MemberEditNickname() throws Exception {
+        //TODO 생성 메서드 개발
         memberService.register(uid, name, email, nickname, imgUrl);
         Map<String, String> map = new HashMap<>();
         map.put("nickname", "김상운");
@@ -134,7 +136,7 @@ class MemberControllerTest extends BaseControllerTest {
     @Test
     @DisplayName("회원 조회 테스트")
     void memberInfoTest() throws Exception {
-
+        //TODO 생성 메서드 개발
         memberService.register(uid, name, email, nickname, imgUrl);
 
         ResultActions resultActions = mockMvc.perform(

--- a/src/test/java/couch/camping/controller/member/MemberControllerTest.java
+++ b/src/test/java/couch/camping/controller/member/MemberControllerTest.java
@@ -1,31 +1,159 @@
 package couch.camping.controller.member;
 
 import couch.camping.common.BaseControllerTest;
-import couch.camping.controller.test.TestController;
+import couch.camping.controller.member.dto.request.MemberSaveRequestDto;
+import couch.camping.domain.member.service.MemberService;
 import lombok.extern.slf4j.Slf4j;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.ResultActions;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.web.context.WebApplicationContext;
 
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import javax.servlet.Filter;
+import java.nio.charset.StandardCharsets;
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
+
+//MockMvcRequestBuilders
+//요청 데이터를 설정할 때 사용할 static 메서드
+//MockMvcResultMatchers
+//실행 결과를 검증할 때 사용할 static 메서드
+//MockMvcResultHandlers
+//실행 결과를 로그 등으로 출력할 때 사용할 static 메서드
 
 @Slf4j
 class MemberControllerTest extends BaseControllerTest {
 
+    private static final String uid = "abcd";
+    private static final String email = "abcd@daum.com";
+    private static final String name = "성이름";
+    private static final String nickname = "abcd";
+    private static final String imgUrl = "https://www.balladang.com";
+
+    @Autowired
+    private WebApplicationContext wac;
+
+    @Autowired
+    private MemberService memberService;
+
+    @Autowired
+    private Filter springSecurityFilterChain;
+
     @BeforeEach
-    public void before() {
-        mockMvc = MockMvcBuilders.standaloneSetup(TestController.class)
+    public void beforeEach() {
+        mockMvc = MockMvcBuilders.webAppContextSetup(wac)
+                .addFilter(springSecurityFilterChain)
                 .build();
     }
 
     @Test
-    public void registerMemberTest() throws Exception {
-        mockMvc.perform(get("/test"))
-                .andExpect(content().string("okk"))// 여기부터 검증
-                .andExpect(status().isOk());// 여기부터 검증
+    @DisplayName("로컬 회원 가입 테스트")
+    void registerMemberTest() throws Exception {
+
+        MemberSaveRequestDto localMember = MemberSaveRequestDto.builder()
+                .uid(uid)
+                .email(email)
+                .name(name)
+                .nickname(nickname)
+                .imgUrl(imgUrl)
+                .build();
+
+
+        ResultActions resultActions = mockMvc.perform(
+                post("/members/local")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .characterEncoding(StandardCharsets.UTF_8)
+                        .content(objectMapper.writeValueAsString(localMember))
+                        .accept(MediaType.APPLICATION_JSON)
+        )
+                .andDo(print());
+
+        resultActions
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("uid").value(uid))
+                .andExpect(jsonPath("email").value(email))
+                .andExpect(jsonPath("name").value(name))
+                .andExpect(jsonPath("nickname").value(nickname))
+                .andExpect(jsonPath("imgUrl").value(imgUrl));
     }
+    
+    @Test
+    @DisplayName("로그인 테스트")
+    void memberLoginTest() throws Exception {
+        memberService.register(uid, name, email, nickname, imgUrl);
+
+        ResultActions resultActions = mockMvc.perform(
+                get("/members/me")
+                        .header("Authorization", "Bearer " + uid)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .characterEncoding(StandardCharsets.UTF_8)
+                        .accept(MediaType.APPLICATION_JSON)
+        )
+                .andDo(print());
+
+        resultActions
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("uid").value(uid))
+                .andExpect(jsonPath("email").value(email))
+                .andExpect(jsonPath("name").value(name))
+                .andExpect(jsonPath("nickname").value(nickname))
+                .andExpect(jsonPath("imgUrl").value(imgUrl));
+    }
+    
+    @Test
+    @DisplayName("닉네임 수정 테스트")
+    void MemberEditNickname() throws Exception {
+        memberService.register(uid, name, email, nickname, imgUrl);
+        Map<String, String> map = new HashMap<>();
+        map.put("nickname", "김상운");
+
+        ResultActions resultActions = mockMvc.perform(
+                patch("/members/me")
+                        .header("Authorization", "Bearer " + uid)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .characterEncoding(StandardCharsets.UTF_8)
+                        .accept(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(map))
+        )
+                .andDo(print());
+
+        resultActions
+                .andExpect(status().isNoContent());
+    }
+    
+    @Test
+    @DisplayName("회원 조회 테스트")
+    void memberInfoTest() throws Exception {
+
+        memberService.register(uid, name, email, nickname, imgUrl);
+
+        ResultActions resultActions = mockMvc.perform(
+                get("/members/me/info")
+                        .header("Authorization", "Bearer " + uid)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .characterEncoding(StandardCharsets.UTF_8)
+                        .accept(MediaType.APPLICATION_JSON)
+        )
+                .andDo(print());
+
+        resultActions
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("uid").value(uid))
+                .andExpect(jsonPath("email").value(email))
+                .andExpect(jsonPath("name").value(name))
+                .andExpect(jsonPath("nickname").value(nickname))
+                .andExpect(jsonPath("imgUrl").value(imgUrl));
+    }
+
 
 }

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -1,7 +1,7 @@
 
 spring:
   datasource:
-    url: jdbc:mysql://localhost:3306/camp?serverTimezone=Asia/Seoul&characterEncoding=UTF-8
+    url: jdbc:mysql://localhost:3306/camp_test?serverTimezone=Asia/Seoul&characterEncoding=UTF-8
     username: root
     password: 369369rt
     driver-class-name: com.mysql.cj.jdbc.Driver


### PR DESCRIPTION
<br/>

## 해당 이슈 📎

- issue title #116

  <br/>

## 변경 사항 🛠
- post, comment 엔티티 JpaAuditing 기능을 수동으로 변경
- 비지니스 로직상 좋아요를 누르거나, 자식 엔티티 수정 시 해당 엔티티 혹은 부모 엔티티가 수정되므로 수동으로 변경하였습니다.
<br/>

## 리뷰어 참고 사항 🙋‍♀️
- post, comment 엔티티와, 각 서비스 메서드인 write 와 edit 만 수정하였습니다. 확인 부탁드립니다.

<br/>
