### PR TITLE
REFACTOR: 게시글, 댓글 삭제를 위한 각 엔티티에 알림과 일대다 연관관계 추가

### DIFF
--- a/src/main/java/couch/camping/controller/post/dto/response/PostEditResponseDto.java
+++ b/src/main/java/couch/camping/controller/post/dto/response/PostEditResponseDto.java
@@ -14,6 +14,7 @@ import java.util.List;
 @Getter @Setter
 @Builder
 @ApiModel(description = "커뮤니티 게시글 수정 응답 DTO")
+@EqualsAndHashCode
 public class PostEditResponseDto {
 
     @ApiModelProperty(required = true, value = "게시글 ID", example = "2821")

--- a/src/main/java/couch/camping/domain/comment/entity/Comment.java
+++ b/src/main/java/couch/camping/domain/comment/entity/Comment.java
@@ -2,6 +2,7 @@ package couch.camping.domain.comment.entity;
 
 import couch.camping.domain.commentlike.entity.CommentLike;
 import couch.camping.domain.member.entity.Member;
+import couch.camping.domain.notification.entity.Notification;
 import couch.camping.domain.post.entity.Post;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -39,6 +40,14 @@ public class Comment {
     @Builder.Default
     @OneToMany(mappedBy = "comment", cascade = CascadeType.REMOVE, orphanRemoval = true)
     List<CommentLike> commentLikeList = new ArrayList<>();
+
+    @Builder.Default
+    @OneToMany(mappedBy = "comment", cascade = CascadeType.REMOVE, orphanRemoval = true)
+    List<Notification> notificationList = new ArrayList<>();
+
+    @Builder.Default
+    @OneToMany(mappedBy = "writeComment", cascade = CascadeType.REMOVE, orphanRemoval = true)
+    List<Notification> notificationWriteList = new ArrayList<>();
 
     @Lob
     private String content;

--- a/src/main/java/couch/camping/domain/post/entity/Post.java
+++ b/src/main/java/couch/camping/domain/post/entity/Post.java
@@ -2,6 +2,7 @@ package couch.camping.domain.post.entity;
 
 import couch.camping.domain.comment.entity.Comment;
 import couch.camping.domain.member.entity.Member;
+import couch.camping.domain.notification.entity.Notification;
 import couch.camping.domain.postimage.entity.PostImage;
 import couch.camping.domain.postlike.entity.PostLike;
 import lombok.AllArgsConstructor;
@@ -44,6 +45,10 @@ public class Post {
     @Builder.Default
     @OneToMany(mappedBy = "post", cascade = CascadeType.REMOVE, orphanRemoval = true)
     private List<PostLike> postLikeList = new ArrayList<>();
+
+    @Builder.Default
+    @OneToMany(mappedBy = "post", cascade = CascadeType.REMOVE, orphanRemoval = true)
+    private List<Notification> notificationList = new ArrayList<>();
 
     private String title;
 

--- a/src/test/java/couch/camping/domain/post/service/PostServiceLocalImplTest.java
+++ b/src/test/java/couch/camping/domain/post/service/PostServiceLocalImplTest.java
@@ -1,6 +1,8 @@
 package couch.camping.domain.post.service;
 
+import couch.camping.controller.post.dto.request.PostEditRequestDto;
 import couch.camping.controller.post.dto.request.PostWriteRequestDto;
+import couch.camping.controller.post.dto.response.PostEditResponseDto;
 import couch.camping.controller.post.dto.response.PostWriteResponseDto;
 import couch.camping.domain.member.entity.Member;
 import couch.camping.domain.notification.repository.NotificationRepository;
@@ -24,6 +26,7 @@ import org.springframework.security.core.userdetails.UserDetailsService;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
@@ -35,6 +38,7 @@ import static org.mockito.Mockito.when;
 class PostServiceLocalImplTest {
     
     //member 필드
+    private static Long memberId = 1L;
     private static final String uid = "abcd";
     private static final String email = "abcd@daum.com";
     private static final String name = "성이름";
@@ -42,6 +46,7 @@ class PostServiceLocalImplTest {
     private static final String imgUrl = "https://www.balladang.com";
     
     //post 필드
+    private static Long postId = 1L;
     private static String title = "캠핑장 같이 가실 분~?";
     private static String content = "장비는 제가 준비 하겠습니다.";
     private static String postType = "free";
@@ -71,7 +76,7 @@ class PostServiceLocalImplTest {
     @BeforeEach
     void before() {
         member = Member.builder()
-                .id(1L)
+                .id(memberId)
                 .uid(uid)
                 .email(email)
                 .name(name)
@@ -127,4 +132,35 @@ class PostServiceLocalImplTest {
         assertThat(postServiceLocal.writePost(postWriteRequestDto, member)).isEqualTo(postWriteResponseDto);
     }
     
+    @Test
+    @DisplayName("게시글 수정 테스트")
+    void editPostTest() {
+
+        //given
+        String editTitle = "수정 제목";
+        String editContent = "수정 내용";
+        String editPostType = "picture";
+        List<String> editImgUrlList = Arrays.asList("www.picture.com");
+
+        PostEditRequestDto postEditRequestDto = PostEditRequestDto.builder()
+                .title(editTitle)
+                .content(editContent)
+                .postType(editPostType)
+                .imgUrlList(editImgUrlList)
+                .build();
+
+        PostEditResponseDto postEditResponseDto = PostEditResponseDto.builder()
+                .postId(postId)
+                .title(editTitle)
+                .content(editContent)
+                .postType(editPostType)
+                .imgUrlList(editImgUrlList)
+                .build();
+
+        //when
+        when(postRepository.findById(any())).thenReturn(Optional.ofNullable(post));
+        
+        //then
+        assertThat(postServiceLocal.editPost(postId, member, postEditRequestDto)).isEqualTo(postEditResponseDto);
+    }
 }


### PR DESCRIPTION
<br/>

## 해당 이슈 📎

- issue title #132 

  <br/>

## 개발 사항 🛠
- notification 엔티티와 연관관계를 맺고 있는데 인테테에 일대다 연관관계와 cascade 옵션은 REMOVE 로 설정하였습니다.
<br/>

## 리뷰어 참고 사항 🙋‍♀️
<br/>
- cascade 옵션의 REMOVE 를 봐주세요.